### PR TITLE
Start timer counter at 1 instead of 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = Timer
 
 function Timer(currentTime) {
     var callbacks = []
-    var counter = 0
+    var counter = 1
 
     return {
         setTimeout: setTimeout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-mock",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Easily manipulate and mock out time in your tests",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",


### PR DESCRIPTION
This allows for foo = setTimeout(...); if (foo) {} to work similarly to real
timeouts.

Also ticked version forward to 0.1.3.

Addresses https://github.com/Colingo/time-mock/issues/1
